### PR TITLE
tip about installing asciidoctor on Windows

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -116,6 +116,8 @@ TIP: The benefit of using a Linux package manager to install the gem is that it 
 The drawback is that the package may not be available immediately after the release of the gem.
 If you need the latest version, you can always fallback to using the `gem` command.
 
+TIP: If you are working on Windows, you may get this error : `ERROR:  While executing gem ... (Encoding::UndefinedConversionError)`. In that case, you have to change the code page used by your command line. This is done by executing `chcp 1252`. Then use the following commands as stated.
+
 === (a) gem install
 
 Open a terminal and type: (without the leading `$`)


### PR DESCRIPTION
Windows command line is not set by default with the encoding used by gem. This commit adds a tip in order to instruct how to fix this problem on windows.